### PR TITLE
Fix redux compose undefined error

### DIFF
--- a/resources/assets/js/store/create-store.js
+++ b/resources/assets/js/store/create-store.js
@@ -1,6 +1,6 @@
 /* global compose */
 import thunk from 'redux-thunk'
-import { createStore, applyMiddleware } from 'redux'
+import { createStore, applyMiddleware, compose } from 'redux'
 import createHistory from 'history/createBrowserHistory'
 import { routerMiddleware } from 'react-router-redux'
 


### PR DESCRIPTION
Fix `Uncaught ReferenceError: compose is not defined` in `create-store`